### PR TITLE
discard note sections in the linker script

### DIFF
--- a/bench/config.h
+++ b/bench/config.h
@@ -1,28 +1,50 @@
 /* processor specific configs */
+#ifndef HAS_E64
 #define HAS_E64 1
+#endif
+
+#ifndef HAS_F16
 #define HAS_F16 0
+#endif
 
 /* the maximum number of bytes to allocate, minimum of 4096 */
-// #define MAX_MEM (1024*1024*32)
-#define MAX_MEM (1024*4)
+// #define MAX_MEM (1024*4)
+#ifndef MAX_MEM
+#define MAX_MEM (1024*1024*32)
+#endif
+
 /* the byte count for the next run */
+#ifndef NEXT
 #define NEXT(c) (c + c/7 + 3)
+#endif
 
 /* minimum number of repeats, to sample median from */
+#ifndef MIN_REPEATS
 #define MIN_REPEATS 10
+#endif
+
 /* maxium number of repeats, executed until more than STOP_TIME has elapsed */
+#ifndef MAX_REPEATS
 #define MAX_REPEATS 64
+#endif
 
-/* stop repeats early afer this many cycles have elapsed */
+/* stop repeats early after this many cycles have elapsed */
+#ifndef STOP_CYCLES
 #define STOP_CYCLES (1024*1024*500)
-
+#endif
 
 /* custom scaling factors for benchmarks, these are used to make sure each
  * benchmark approximately takes the same amount of time. */
 
+#ifndef SCALE_mandelbrot
 #define SCALE_mandelbrot(N) ((N)/10)
+#endif
+
+#ifndef SCALE_mergelines
 #define SCALE_mergelines(N) ((N)/10)
+#endif
 
 /* benchmark specific configurations */
+#ifndef mandelbrot_ITER
 #define mandelbrot_ITER 100
-
+#endif

--- a/config.mk
+++ b/config.mk
@@ -5,17 +5,19 @@ WARN=-Wall -Wextra -Wno-unused-function -Wno-unused-parameter
 # CC=clang
 # CFLAGS=--target=riscv64 -march=rv64gcv_zfh -O3 ${WARN} -nostdlib -fno-builtin -ffreestanding
 
-# full cross compilation toolchain
-CC		  = riscv64-unknown-linux-gnu-gcc
-OBJDUMP   = riscv64-unknown-linux-gnu-objdump
-OBJCOPY   = riscv64-unknown-linux-gnu-objcopy
-AS		  = riscv64-unknown-linux-gnu-gcc
-LD 		  = riscv64-unknown-linux-gnu-ld
-CFLAGS= -march=rv64gv -mcmodel=medany -fno-builtin -nostdlib -ffreestanding\
-			-O3 -MMD -Wall ${WARN}
+# This is meant to specify the toolchain prefix to ensure compatibility across distros.
+CROSS_COMPILE ?= riscv64-unknown-linux-gnu-
+# This is meant to override configuration definitions in `bench/config.h`
+CONFIG_FLAGS ?= -DMAX_MEM=33554432 # 1024*1024*32
 
+# full cross compilation toolchain
+CC		  = ${CROSS_COMPILE}gcc
+OBJDUMP   = ${CROSS_COMPILE}objdump
+OBJCOPY   = ${CROSS_COMPILE}objcopy
+AS		  = ${CROSS_COMPILE}gcc
+LD 		  = ${CROSS_COMPILE}ld
+CFLAGS = ${CONFIG_FLAGS} -march=rv64gv -mcmodel=medany -fno-builtin -nostdlib -ffreestanding -O3 -MMD -Wall ${WARN}
 
 # native build
 #CC=cc
 #CFLAGS=-march=rv64gcv -O3 ${WARN}
-

--- a/thirdparty/link.ld
+++ b/thirdparty/link.ld
@@ -36,4 +36,7 @@ SECTIONS {
   _heap_start = ALIGN(0x1000);
   _pmem_start = pmem_base;
   _pmem_end = _pmem_start + LENGTH(ram);
+  /DISCARD/ : {
+    *(.note.*)
+  }
 }


### PR DESCRIPTION
Certain toolchain can produce a note section in object files. If this section ends up in the final image file, it can render the image unusable.

This commit fixes this problem by adding directives to the linker script to discard all note sections.